### PR TITLE
Fix crashing on install with "Unknown command '--embedded' given"

### DIFF
--- a/src/emsdk.js
+++ b/src/emsdk.js
@@ -25,11 +25,10 @@ const common = require('./common.js');
 const version = require('./version.js');
 
 function emsdk(args, opts = {}) {
-    const emsdkArgs = ['--embedded'].concat(args);
     const emsdkDir = common.emsdkBase();
     const suffix = (process.platform === 'win32') ? '.bat' : '';
     const emsdk = path.join(emsdkDir, 'emsdk' + suffix);
-    return common.run(emsdk, emsdkArgs, opts);
+    return common.run(emsdk, args, opts);
 }
 
 if (require.main === module) {

--- a/src/emsdk.js
+++ b/src/emsdk.js
@@ -25,11 +25,10 @@ const common = require('./common.js');
 const version = require('./version.js');
 
 function emsdk(args, opts = {}) {
-    const emsdkArgs = args.concat('--embedded');
     const emsdkDir = common.emsdkBase();
     const suffix = (process.platform === 'win32') ? '.bat' : '';
     const emsdk = path.join(emsdkDir, 'emsdk' + suffix);
-    return common.run(emsdk, emsdkArgs, opts);
+    return common.run(emsdk, args, opts);
 }
 
 if (require.main === module) {

--- a/src/emsdk.js
+++ b/src/emsdk.js
@@ -25,10 +25,11 @@ const common = require('./common.js');
 const version = require('./version.js');
 
 function emsdk(args, opts = {}) {
+    const emsdkArgs = args.concat('--embedded');
     const emsdkDir = common.emsdkBase();
     const suffix = (process.platform === 'win32') ? '.bat' : '';
     const emsdk = path.join(emsdkDir, 'emsdk' + suffix);
-    return common.run(emsdk, args, opts);
+    return common.run(emsdk, emsdkArgs, opts);
 }
 
 if (require.main === module) {


### PR DESCRIPTION
Resolves #4, with the cause originally found by @rebior in https://github.com/devappd/emscripten-sdk-npm/issues/4#issuecomment-813647863

This PR just simply ~~removes adding "--embedded" as described by rebior~~ ~~swaps the position of "--embedded" to the end instead of the front.~~ removes adding "--embedded" as it is now removed completely from emsdk, and will cause the commands to fail.