### PR TITLE
#8 - Replace .txt in common.js with .json

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -60,7 +60,7 @@ function run(command, args, opts = {}) {
 ////////////////////////////////////////////////////////////////////////
 
 function getReleaseTags() {
-    let tagsFile = path.join(emsdkBase(), 'emscripten-releases-tags.txt');
+    let tagsFile = path.join(emsdkBase(), 'emscripten-releases-tags.json');
     let rawData = fs.readFileSync(tagsFile);
     return JSON.parse(rawData);
 }


### PR DESCRIPTION
This PR fixes a problem caused by a change in the emsdk repo that renamed `emscripten-releases-tags.txt` to `emscripten-releases-tags.json`.